### PR TITLE
Update juice and more

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+access = public
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "event-stream": "^3.3.4",
     "gulp-util": "^3.0.7",
-    "juice": "^3.0.1"
+    "juice": "^4.0.0"
   },
   "keywords": [
     "gulpplugin",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "description": "process html files through juice to inline CSS",
   "version": "0.1.0",
   "author": "Lucas Hrabovsky <hrabovsky.lucas@gmail.com> (http://imlucas.com)",
+  "contributors": [
+    "Zeb Pykosz <zeb.apy@gmail.com> (http://zeb.codes/)",
+    "Akzhan Abdulin <akzhan.abdulin@gmail.com> (http://akzhan.github.io/)"
+  ],
   "license": "MIT",
   "homepage": "http://github.com/zebapy/gulp-juice",
   "repository": {


### PR DESCRIPTION
1) Update juice dependency to ^4.0.0

2) Allow to public scope package.

* You need to change name to `@zebapy/gulp-juice` before publishing.
* I was published `@akzhan/gulp-juice` with rebased to my repo updates.